### PR TITLE
Fix context timeout

### DIFF
--- a/monitor/caller/impl.go
+++ b/monitor/caller/impl.go
@@ -91,14 +91,14 @@ func (ac apiCall) PrimeDescribeTradingWallets() (WalletLookup, error) {
 
 func (ac apiCall) PrimeDescribeProducts() (ProductLookup, error) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), ac.config.PrimeCallTimeout())
-	defer cancel()
-
 	products := make(ProductLookup)
 
 	var cursor string
 
 	for {
+
+		ctx, cancel := context.WithTimeout(context.Background(), ac.config.PrimeCallTimeout())
+		defer cancel()
 
 		request := &prime.ListProductsRequest{
 			PortfolioId: ac.portfolioId,


### PR DESCRIPTION
The context timeout was outside of a loop causing a slew of timeout errors.